### PR TITLE
Prevent memory leaks and improve performance

### DIFF
--- a/blurkit/src/main/java/io/alterac/blurkit/BlurKit.java
+++ b/blurkit/src/main/java/io/alterac/blurkit/BlurKit.java
@@ -56,9 +56,11 @@ public class BlurKit {
         );
 
         Canvas canvas = new Canvas(bitmap);
-        Matrix matrix = new Matrix();
-        matrix.preScale(downscaleFactor, downscaleFactor);
-        canvas.setMatrix(matrix);
+        if (downscaleFactor != FULL_SCALE) {
+            Matrix matrix = new Matrix();
+            matrix.preScale(downscaleFactor, downscaleFactor);
+            canvas.setMatrix(matrix);
+        }
         src.draw(canvas);
 
         return bitmap;

--- a/blurkit/src/main/java/io/alterac/blurkit/BlurKit.java
+++ b/blurkit/src/main/java/io/alterac/blurkit/BlurKit.java
@@ -4,11 +4,11 @@ import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
 import android.graphics.Matrix;
-import android.view.View;
 import android.renderscript.Allocation;
 import android.renderscript.Element;
 import android.renderscript.RenderScript;
 import android.renderscript.ScriptIntrinsicBlur;
+import android.view.View;
 
 public class BlurKit {
 
@@ -24,7 +24,7 @@ public class BlurKit {
         }
 
         instance = new BlurKit();
-        rs = RenderScript.create(context);
+        rs = RenderScript.create(context.getApplicationContext());
     }
 
     public Bitmap blur(Bitmap src, int radius) {


### PR DESCRIPTION
* In case someone passes an activity, we need to make sure we are using the application context.
* In case there is no `downscaleFactor` set, we don't need to apply a matrix to the canvas