### PR TITLE
Api to set LifecycleOwner for BlurLayout

### DIFF
--- a/blurkit/build.gradle
+++ b/blurkit/build.gradle
@@ -41,6 +41,8 @@ dependencies {
     androidTestImplementation 'com.android.support.test:rules:1.0.2'
     androidTestImplementation 'org.hamcrest:hamcrest-library:1.3'
 
+    // lifecycle
+    implementation "android.arch.lifecycle:runtime:1.1.1"
 }
 
 install {

--- a/blurkit/src/test/java/io/alterac/blurkit/BlurLayoutTest.java
+++ b/blurkit/src/test/java/io/alterac/blurkit/BlurLayoutTest.java
@@ -1,6 +1,10 @@
 package io.alterac.blurkit;
 
+import android.arch.lifecycle.Lifecycle;
+import android.arch.lifecycle.LifecycleObserver;
+import android.arch.lifecycle.LifecycleOwner;
 import android.content.Context;
+import android.support.annotation.NonNull;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -16,6 +20,32 @@ public class BlurLayoutTest {
 
     public static final int TEST_INT = 1;
     private static final float TEST_FLOAT = 1.1f;
+    private static final LifecycleOwner LIFECYCLE_OWNER = new LifecycleOwner() {
+
+        private final Lifecycle lifecycle = new Lifecycle() {
+            @Override
+            public void addObserver(@NonNull LifecycleObserver observer) {
+
+            }
+
+            @Override
+            public void removeObserver(@NonNull LifecycleObserver observer) {
+
+            }
+
+            @NonNull
+            @Override
+            public Lifecycle.State getCurrentState() {
+                return State.DESTROYED;
+            }
+        };
+
+        @NonNull
+        @Override
+        public Lifecycle getLifecycle() {
+            return lifecycle;
+        }
+    };
 
     private BlurLayout blurLayout;
 
@@ -60,4 +90,9 @@ public class BlurLayoutTest {
         blurLayout.lockView();
     }
 
+    @Test
+    public void setLifecycleOwnerTest() {
+        blurLayout.setLifecycleOwner(LIFECYCLE_OWNER);
+        assertEquals(blurLayout.getLifecycle(), LIFECYCLE_OWNER.getLifecycle());
+    }
 }

--- a/demo/src/main/java/io/alterac/blurkit/demo/MainActivity.java
+++ b/demo/src/main/java/io/alterac/blurkit/demo/MainActivity.java
@@ -16,8 +16,9 @@ public class MainActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
-        blurLayout = (BlurLayout) findViewById(R.id.blurLayout);
+        blurLayout = findViewById(R.id.blurLayout);
 
+        blurLayout.setLifecycleOwner(this);
         blurLayout.animate().translationY(movement).setDuration(1500).setListener(new AnimatorListenerAdapter() {
             @Override
             public void onAnimationEnd(Animator animation) {
@@ -31,13 +32,6 @@ public class MainActivity extends AppCompatActivity {
     @Override
     protected void onStart() {
         super.onStart();
-        blurLayout.startBlur();
         blurLayout.lockView();
-    }
-
-    @Override
-    protected void onStop() {
-        super.onStop();
-        blurLayout.pauseBlur();
     }
 }


### PR DESCRIPTION
Not sure if this change is welcomed. Let me know what you think anyways.

- with the Lifecycle provided by the LifecycleOwner we can remove
  boilerplate calls to startBlur() and pauseBlur(). BlurLayout
  will implement LifecycleObserver for this.
- added dependency on android.arch.lifecycle:runtime:1.1.1 for the
  same
- better not to use this API while using Java 8
