### PR TITLE
fixed:this commit can help BlurLayout support using in Fragment

### DIFF
--- a/blurkit/src/main/java/io/alterac/blurkit/BlurLayout.java
+++ b/blurkit/src/main/java/io/alterac/blurkit/BlurLayout.java
@@ -299,14 +299,27 @@ public class BlurLayout extends FrameLayout {
      * @return View reference for whole activity.
      */
     private View getActivityView() {
-        Activity activity;
-        try {
-            activity = (Activity) getContext();
-        } catch (ClassCastException e) {
-            return null;
+        Activity activity = getActivity(getContext());
+        if (activity == null) {
+            return null
         }
-
         return activity.getWindow().getDecorView().findViewById(android.R.id.content);
+    }
+
+    /**
+     * Casts context to Activity
+     * @param context
+     * @return
+     */
+    private Activity getActivity(Context context) {
+        if (context == null) {
+            return null;
+        } else if (context instanceof Activity) {
+            return (Activity) context;
+        } else if (context instanceof ContextWrapper) {
+            return getActivity(((ContextWrapper) context).getBaseContext());
+        }
+        return null;
     }
 
     /**


### PR DESCRIPTION
because when in Fragment,the code

```
try {
            activity = (Activity) getContext();
        } catch (ClassCastException e) {
            return null;
        }
```
will cause ClassCastException and return null